### PR TITLE
Write (and read) to variable file for persistent values across restarts

### DIFF
--- a/Config/blobifier.cfg
+++ b/Config/blobifier.cfg
@@ -58,9 +58,9 @@ maximum_servo_angle: 180
 pin: ^PG15 # The pullup ( ^ ) is important here.
 press_gcode:
   M117 bucket installed
-  _BLOBIFIER_COUNT_RESET
 release_gcode:
   M117 bucket removed
+  _BLOBIFIER_COUNT_RESET
 
 ##########################################################################################
 # Main macro. Usually you should only need to call this one or place it in the Happy Hare
@@ -518,6 +518,9 @@ variable_current_blobs: 0
 variable_last_shake: 0
 variable_next_shake: 0
 gcode:
+  {% set current_blobs = printer.save_variables.variables.blobifier_current_blobs %} # get count from variables file
+  {% set last_shake = printer.save_variables.variables.blobifier_last_shake %} # get count from variables file
+  {% set next_shake = printer.save_variables.variables.blobifier_next_shake %} # get count from variables file
   {% set bl = printer['gcode_macro BLOBIFIER'] %}
   {% set count = printer['gcode_macro _BLOBIFIER_COUNT'] %}
   {% if current_blobs >= bl.max_blobs %}
@@ -526,6 +529,7 @@ gcode:
     PAUSE
   {% else %}
     SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE={current_blobs + 1}
+    SAVE_VARIABLE VARIABLE=blobifier_current_blobs VALUE={(current_blobs + 1)} # write count to variables file
     {action_respond_info("Blobs in bucket: %s/%s. Next shake @ %s" % (current_blobs + 1, bl.max_blobs, next_shake))}
   {% endif %}
 
@@ -535,7 +539,9 @@ gcode:
 [gcode_macro _BLOBIFIER_COUNT_RESET]
 gcode:
   SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=current_blobs VALUE=0
+  SAVE_VARIABLE VARIABLE=blobifier_current_blobs VALUE=0 # reset count to variables file
   SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=last_shake VALUE=0
+  SAVE_VARIABLE VARIABLE=blobifier_last_shake VALUE=0 # reset count to variables file
   _BLOBIFIER_CALCULATE_NEXT_SHAKE
 
 ##########################################################################################
@@ -555,6 +561,7 @@ gcode:
 
   
   SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=last_shake VALUE={count.current_blobs}
+  SAVE_VARIABLE VARIABLE=blobifier_last_shake VALUE={count.current_blobs} # write count to variables file
   SAVE_GCODE_STATE NAME=shake_bucket
   
   M400
@@ -606,6 +613,7 @@ gcode:
 
   {% set remaining_blobs = bl.max_blobs - count.last_shake %}
   {% set next_shake = (1 - bl.bucket_shake_frequency) * remaining_blobs + count.last_shake %}
+  SAVE_VARIABLE VARIABLE=blobifier_next_shake VALUE={(1 - bl.bucket_shake_frequency) * remaining_blobs + count.last_shake} # write to variables
   _BLOBIFIER_SET_NEXT_SHAKE VALUE={next_shake|int}
 
 ##########################################################################################
@@ -617,6 +625,7 @@ gcode:
   {% if params.VALUE %}
     {% set next_shake = params.VALUE %}
     SET_GCODE_VARIABLE MACRO=_BLOBIFIER_COUNT VARIABLE=next_shake VALUE={next_shake}
+    SAVE_VARIABLE VARIABLE=blobifier_next_shake VALUE={next_shake} # write to variables file
   {% else %}
     {action_respond_info("Provide parameter VALUE=")}
   {% endif %}


### PR DESCRIPTION
First attempt at writing and reading blob counts, next shake, and last shake variables into the [save_variables] file (which should be enabled as part of the Happy Hare coding.

I moved the _BLOBIFIER_COUNT_RESET command to run when the bucket is removed and not installed as on a FIRMWARE_RESTART the switch is initialised as a press_gcode and would reset the stats back to zero!

I've testing this in theory and it seems to work but it does need more testing on long prints.

Apologies if this is code is not "best practice" as I am not a developer (just a tinkerer!)